### PR TITLE
Added naming conventions for clarity (#131)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ The following core features will be available in this project:
 - ### Naming conventions
   - camelCase for variables, functions and objects
   - PascalCase for React components, Typescript types and classes
+  - snake_case in python for variables, functions and objects
 
 - ### Deployment
   - Docker


### PR DESCRIPTION
- Added naming conventions that were missing

Linked issue: #131 